### PR TITLE
replace panic to std::io::Error

### DIFF
--- a/src/doc.rs
+++ b/src/doc.rs
@@ -71,11 +71,16 @@ pub(crate) fn open_doc_read_data<P: AsRef<Path>>(
                     }
                 }
                 Ok(Event::Eof) => break,
-                Err(e) => panic!(
-                    "Error at position {}: {:?}",
-                    xml_reader.buffer_position(),
-                    e
-                ),
+                Err(e) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        format!(
+                            "Error at position {}: {:?}",
+                            xml_reader.buffer_position(),
+                            e
+                        ),
+                    ))
+                }
                 _ => (),
             }
         }

--- a/src/docx.rs
+++ b/src/docx.rs
@@ -67,11 +67,16 @@ impl MsDoc<Docx> for Docx {
                         }
                     }
                     Ok(Event::Eof) => break, // exits the loop when reaching end of file
-                    Err(e) => panic!(
-                        "Error at position {}: {:?}",
-                        xml_reader.buffer_position(),
-                        e
-                    ),
+                    Err(e) => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::Other,
+                            format!(
+                                "Error at position {}: {:?}",
+                                xml_reader.buffer_position(),
+                                e
+                            ),
+                        ))
+                    }
                     _ => (),
                 }
             }

--- a/src/odp.rs
+++ b/src/odp.rs
@@ -74,7 +74,16 @@ impl OpenOfficeDoc<Odp> for Odp {
         //                 }
         //             },
         //             Ok(Event::Eof) => break,
-        //             Err(e) => panic!("Error at position {}: {:?}", xml_reader.buffer_position(), e),
+        //             Err(e) => {
+        //                 return Err(io::Error::new(
+        //                    io::ErrorKind::Other,
+        //                    format!(
+        //                        "Error at position {}: {:?}",
+        //                        xml_reader.buffer_position(),
+        //                        e
+        //                    ),
+        //                ))
+        //            }
         //             _ => (),
         //         }
         //     }

--- a/src/pptx.rs
+++ b/src/pptx.rs
@@ -70,11 +70,16 @@ impl MsDoc<Pptx> for Pptx {
                         }
                     }
                     Ok(Event::Eof) => break, // exits the loop when reaching end of file
-                    Err(e) => panic!(
-                        "Error at position {}: {:?}",
-                        xml_reader.buffer_position(),
-                        e
-                    ),
+                    Err(e) => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::Other,
+                            format!(
+                                "Error at position {}: {:?}",
+                                xml_reader.buffer_position(),
+                                e
+                            ),
+                        ))
+                    }
                     _ => (),
                 }
             }

--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -75,11 +75,16 @@ impl MsDoc<Xlsx> for Xlsx {
                         }
                     }
                     Ok(Event::Eof) => break, // exits the loop when reaching end of file
-                    Err(e) => panic!(
-                        "Error at position {}: {:?}",
-                        xml_reader.buffer_position(),
-                        e
-                    ),
+                    Err(e) => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::Other,
+                            format!(
+                                "Error at position {}: {:?}",
+                                xml_reader.buffer_position(),
+                                e
+                            ),
+                        ))
+                    }
                     _ => (),
                 }
             }


### PR DESCRIPTION
This pull request replaces all occurrences of panic! with an appropriate io::Error return in order to improve error handling in the library. This change aims to provide better user experience and make the library more robust and reliable.